### PR TITLE
Implement RetractArm and fix missing method

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -53,7 +53,7 @@ public final class Constants {
         public static final int kSlowModeTrigger = Button.kLeftBumper.value;
         public static final int kKillClimber = Button.kB.value;
         public static final int kFireShooter = Button.kRightBumper.value;
-        public static final int kretractArm = Button.kStart.value;
+        public static final int kRetractArm = Button.kStart.value;
       }
 
       public static final class ElevatorConstants {

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -51,6 +51,9 @@ public final class Constants {
         public static final int kSetupForClimb = Button.kY.value;
         public static final int kLiftBallBinding = Button.kX.value;
         public static final int kSlowModeTrigger = Button.kLeftBumper.value;
+        public static final int kKillClimber = Button.kB.value;
+        public static final int kFireShooter = Button.kRightBumper.value;
+        public static final int kretractArm = Button.kStart.value;
       }
 
       public static final class ElevatorConstants {
@@ -67,12 +70,13 @@ public final class Constants {
         public static final double kMaxWinchRotations = 330;
         public static final double kMaxWinchSpeed = -0.2;
         public static final double kMaxDriveSpeed = 0.1;
+        public static final int kMaxLiftCurrent = 25;
       }
 
       public static final class ShooterConstants {
         public static final int kShooterMotorPort = 30;
-        public static final double kShooterSpeed = 1.0;
-        public static final double kBallFiredThreshold = 1;
+        public static final double kShooterSpeed = 0.5;
+        public static final double kBallFiredThreshold = 0.5;
         
       }
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -18,10 +18,12 @@ import frc.robot.Constants.ClimberConstants;
 import frc.robot.Constants.DriveConstants;
 import frc.robot.Constants.OIConstants;
 import frc.robot.commands.DefaultDrive;
+import frc.robot.commands.KillClimber;
 import frc.robot.commands.LiftBall;
 import frc.robot.commands.PickupBall;
+import frc.robot.commands.ShootBall;
 import frc.robot.commands.climb.groups.SetupForClimb;
-import frc.robot.commands.climb.individual.RaiseArm;
+import frc.robot.commands.climb.individual.LowerArm;
 
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a
@@ -66,7 +68,11 @@ public class RobotContainer {
     new JoystickButton(m_driverController, OIConstants.kPickUpBallBinding).whenPressed(new PickupBall(m_robotIntake));
     new JoystickButton(m_driverController, OIConstants.kSetupForClimb).whenPressed(new SetupForClimb(m_robotClimber));
     new JoystickButton(m_driverController, OIConstants.kLiftBallBinding).whenPressed(new LiftBall(m_robotElevator, m_robotIntake));
-    
+    new JoystickButton(m_driverController, OIConstants.kKillClimber).whenPressed(new KillClimber(m_robotClimber));
+    new JoystickButton(m_driverController, OIConstants.kFireShooter).whenPressed(new ShootBall(m_robotShooter, m_robotElevator));
+
+    new JoystickButton(m_driverController, OIConstants.kretractArm).whenPressed(new LowerArm(m_robotClimber));
+
     new JoystickButton(m_driverController, OIConstants.kSlowModeTrigger)
       .whenPressed(() -> m_robotDrive.setMaxOutput(ClimberConstants.kMaxDriveSpeed))
       .whenReleased(() -> m_robotDrive.setMaxOutput(DriveConstants.kMaxSpeed));

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -71,7 +71,7 @@ public class RobotContainer {
     new JoystickButton(m_driverController, OIConstants.kKillClimber).whenPressed(new KillClimber(m_robotClimber));
     new JoystickButton(m_driverController, OIConstants.kFireShooter).whenPressed(new ShootBall(m_robotShooter, m_robotElevator));
 
-    new JoystickButton(m_driverController, OIConstants.kretractArm).whenPressed(new LowerArm(m_robotClimber));
+    new JoystickButton(m_driverController, OIConstants.kRetractArm).whenPressed(new LowerArm(m_robotClimber));
 
     new JoystickButton(m_driverController, OIConstants.kSlowModeTrigger)
       .whenPressed(() -> m_robotDrive.setMaxOutput(ClimberConstants.kMaxDriveSpeed))

--- a/src/main/java/frc/robot/commands/KillClimber.java
+++ b/src/main/java/frc/robot/commands/KillClimber.java
@@ -15,7 +15,7 @@ public class KillClimber extends CommandBase {
     @Override
     public void initialize() {
         m_climberSystem.stopWinch();
-       // m_climberSystem.stopTilt();
+        m_climberSystem.stopTilt();
     }
   
     @Override

--- a/src/main/java/frc/robot/commands/KillClimber.java
+++ b/src/main/java/frc/robot/commands/KillClimber.java
@@ -15,7 +15,7 @@ public class KillClimber extends CommandBase {
     @Override
     public void initialize() {
         m_climberSystem.stopWinch();
-        m_climberSystem.stopTilt();
+       // m_climberSystem.stopTilt();
     }
   
     @Override

--- a/src/main/java/frc/robot/commands/climb/individual/LowerArm.java
+++ b/src/main/java/frc/robot/commands/climb/individual/LowerArm.java
@@ -1,0 +1,47 @@
+package frc.robot.commands.climb.individual;
+
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.Constants.ClimberConstants;
+import frc.robot.subsystems.Climber;
+import frc.robot.subsystems.DriveTrain;
+
+/**
+ * A command to setup the robot for a bar to be climbed.
+ */
+public class LowerArm extends CommandBase {
+  private final Climber m_climber;
+
+  /**
+   * Creates a new SetupForClimb
+   * 
+   * @param climber The climber subsystem this command will run on
+   */
+  public LowerArm(Climber climber) {
+    m_climber = climber;
+  
+    addRequirements(m_climber);
+  }
+
+  @Override
+  public void initialize() {
+    m_climber.retractArm();      
+  }
+
+  
+  @Override
+  public void execute() {
+
+  }
+
+  @Override
+  public boolean isFinished() {
+    return m_climber.ArmIsFullyRetracted();
+  }
+
+  // Called once after isFinished returns true
+  @Override
+  public void end(boolean interrupted) {
+    m_climber.stopWinch();
+  }
+}

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -103,5 +103,9 @@ public class Climber extends SubsystemBase{
           || (Math.abs(m_winchOdometer.getPosition())) > ClimberConstants.kMaxWinchRotations);
 
     }
+
+    public void stopTilt() {
+      m_tiltMotor.stopMotor();
+    }
     
 }

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -10,7 +10,7 @@ import com.revrobotics.CANSparkMax.IdleMode;
 import edu.wpi.first.wpilibj.motorcontrol.MotorController;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-
+import frc.robot.Constants;
 import frc.robot.Constants.ClimberConstants;
 import frc.robot.utility.EncoderOdometer;
 
@@ -37,6 +37,8 @@ public class Climber extends SubsystemBase{
       //m_winchMotor.setInverted(true);
       m_winchMotor.setIdleMode(IdleMode.kBrake);
       m_tiltMotor.setIdleMode(IdleMode.kBrake);
+
+      m_winchMotor.setSmartCurrentLimit(ClimberConstants.kMaxLiftCurrent);
 
       m_winchOdometer = new EncoderOdometer(m_winchEncoder);
     }
@@ -85,6 +87,21 @@ public class Climber extends SubsystemBase{
 
     public void stopWinch() {
       m_winchMotor.stopMotor();
+    }
+
+    public void retractArm() {
+      m_winchMotor.set(ClimberConstants.kMaxWinchSpeed * -1);
+    }
+
+    public boolean ArmIsFullyRetracted() {
+      boolean lowerLimit = m_lowerLimit.isPressed();
+      boolean upperLimit = m_upperLimit.isPressed();
+      SmartDashboard.putBoolean("Upper limit", upperLimit);
+      SmartDashboard.putBoolean("Lower limit", lowerLimit);
+
+      return (m_lowerLimit.isPressed() 
+          || (Math.abs(m_winchOdometer.getPosition())) > ClimberConstants.kMaxWinchRotations);
+
     }
     
 }


### PR DESCRIPTION
RetractArm is a convenience method for use during testing so the climber arm can be easily retracted.
Also added the missing stopTilt() method for KillClimber.